### PR TITLE
implement tests for cache, registry and server

### DIFF
--- a/lib/confluent_schema.ex
+++ b/lib/confluent_schema.ex
@@ -11,7 +11,8 @@ defmodule ConfluentSchema do
   Return `{:error, :not_found}` if the subject is not found.
   Return `{:error, ExJsonSchema.errors()}` if the payload is invalid.
   """
-  @spec validate(map, binary) :: {:ok, map} | {:error, :not_found | ExJsonSchema.errors()}
+  @spec validate(map, binary) ::
+          {:ok, map} | {:error, :not_found} | {:error, ExJsonSchema.errors()} | no_return
   def validate(payload, subject) do
     with {:ok, schema} <- Cache.get(subject),
          :ok <- ExJsonSchema.Validator.validate(schema, payload) do

--- a/lib/confluent_schema/cache.ex
+++ b/lib/confluent_schema/cache.ex
@@ -10,11 +10,14 @@ defmodule ConfluentSchema.Cache do
   ## Example
 
       iex> Cache.start()
-      true
+      :#{@ets_table}
+
+      iex> Cache.start()
+      iex> assert_raise ArgumentError, fn -> Cache.start() end
   """
   @spec start() :: true | no_return
   def start() do
-    @ets_table == :ets.new(@ets_table, [:named_table, read_concurrency: true])
+    :ets.new(@ets_table, [:named_table, read_concurrency: true])
   end
 
   @doc """
@@ -27,8 +30,8 @@ defmodule ConfluentSchema.Cache do
       iex> Cache.set("my-subject", %{"type" => "string"})
       true
 
-      iex> Cache.set("my-subject", %{"type" => "string"})
-      ArgumentError
+      iex> assert_raise ArgumentError, fn -> Cache.set("my-subject", %{"type" => "string"}) end
+      
   """
   @spec set(binary, map) :: true | no_return
   def set(subject, schema) do

--- a/lib/confluent_schema/registry.ex
+++ b/lib/confluent_schema/registry.ex
@@ -12,8 +12,21 @@ defmodule ConfluentSchema.Registry do
 
   ## Examples
 
-      iex> ConfluentSchema.Registry.get_subject_schemas(client)
-      {:ok, %{"subject" => %{type: "record", name: "MyRecord", fields: []}}}
+      iex> client = RegistryMock.create()
+      iex> Registry.get_subject_schemas(client)
+      {:ok, %{"foo" => %{"type" => "string"}, "bar" => %{"type" => "string"}}}
+
+      iex> client = RegistryMock.create_error_subject()
+      iex> Registry.get_subject_schemas(client)
+      {:error, :get_subjects, 404, "Not Found"}
+
+      iex> client = RegistryMock.create_error_schema()
+      iex> Registry.get_subject_schemas(client)
+      {:error, :get_schema, 404, "Not Found"}
+
+      iex> client = RegistryMock.create_error_decode()
+      iex> Registry.get_subject_schemas(client)
+      {:error, :decode_schema, 1, %Jason.DecodeError{position: 0, token: nil, data: "invalid json"}}
   """
   @spec get_subject_schemas(Registry.client()) :: {:ok, map} | {:error, atom(), integer(), any()}
   def get_subject_schemas(client) do

--- a/lib/confluent_schema/server.ex
+++ b/lib/confluent_schema/server.ex
@@ -45,8 +45,9 @@ defmodule ConfluentSchema.Server do
   @spec init(Keyword.t()) :: {:ok, map, {:continue, atom()}}
   def init(opts) do
     Cache.start()
-    state = %{registry: Registry.create(opts), debug: false, period: :timer.minutes(5)}
-    {:ok, state, {:continue, :cache}}
+    default = [debug: false, period: :timer.minutes(5), registry: Registry.create(opts)]
+    state = Keyword.merge(default, opts)
+    {:ok, Map.new(state), {:continue, :cache}}
   end
 
   @doc false
@@ -58,6 +59,7 @@ defmodule ConfluentSchema.Server do
   def handle_info(:cache, state) do
     cache(state.registry, state.debug)
     Process.send_after(self(), :cache, state.period)
+    {:noreply, state}
 
     {:noreply, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,13 @@ defmodule ConfluentSchema.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.
   def application do

--- a/test/confluent_schema/cache_test.exs
+++ b/test/confluent_schema/cache_test.exs
@@ -1,0 +1,5 @@
+defmodule ConfluentSchema.CacheTest do
+  use ExUnit.Case, async: true
+  alias ConfluentSchema.Cache
+  doctest ConfluentSchema.Cache
+end

--- a/test/confluent_schema/registry_test.exs
+++ b/test/confluent_schema/registry_test.exs
@@ -1,0 +1,10 @@
+defmodule ConfluentSchema.RegistryTest do
+  use ExUnit.Case, async: true
+  alias ConfluentSchema.Registry
+  doctest ConfluentSchema.Registry
+
+  setup do
+    RegistryMock.setup()
+    :ok
+  end
+end

--- a/test/confluent_schema/server_test.exs
+++ b/test/confluent_schema/server_test.exs
@@ -1,19 +1,30 @@
 defmodule ConfluentSchema.ServerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+  alias ConfluentSchema.{Cache, Server}
   doctest ConfluentSchema.Server
+  @period 10
 
   setup do
-    opts = [
-      base_url: "https://foobar.region.aws.confluent.cloud",
-      username: "key",
-      password: "secret"
-    ]
-
-    start_supervised!({ConfluentSchema.Server, opts})
-    ConfluentSchema.Server.wait_start()
+    RegistryMock.set_global_subject("foo")
+    Server.start_link(adapter: Tesla.Mock, period: @period)
+    Server.wait_start()
   end
 
-  @tag :skip
+  test "resets cache on start" do
+    assert {:ok, _schema} = Cache.get("foo")
+    assert {:error, :not_found} = Cache.get("bar")
+  end
+
   test "periodically updates cache" do
+    assert {:error, :not_found} = Cache.get("bar")
+    RegistryMock.set_global_subject("bar")
+    assert wait_until(fn -> Cache.get("bar") end)
+  end
+
+  defp wait_until(fun) do
+    case fun.() do
+      {:ok, result} -> result
+      _ -> :timer.sleep(@period) && wait_until(fun)
+    end
   end
 end

--- a/test/support/registry_mock.ex
+++ b/test/support/registry_mock.ex
@@ -1,0 +1,47 @@
+defmodule RegistryMock do
+  import Tesla.Mock
+  alias ConfluentSchema.Registry
+
+  def create(opts \\ []), do: opts |> Keyword.put(:adapter, Tesla.Mock) |> Registry.create()
+  def create_error_subject(), do: create(base_url: "http://localhost:8081/error_subject/")
+  def create_error_schema(), do: create(base_url: "http://localhost:8081/error_schema/")
+  def create_error_decode(), do: create(base_url: "http://localhost:8081/error_decode/")
+
+  def setup() do
+    mock(fn
+      %{method: :get, url: "http://localhost:8081/subjects"} ->
+        json(["foo", "bar"])
+
+      %{method: :get, url: "http://localhost:8081/subjects/foo/versions/latest"} ->
+        json(%{"name" => "foo", "version" => 1, "schema" => "{\"type\": \"string\"}"})
+
+      %{method: :get, url: "http://localhost:8081/subjects/bar/versions/latest"} ->
+        json(%{"name" => "bar", "version" => 1, "schema" => "{\"type\": \"string\"}"})
+
+      %{method: :get, url: "http://localhost:8081/error_subject/subjects"} ->
+        %Tesla.Env{status: 404, body: "Not Found"}
+
+      %{method: :get, url: "http://localhost:8081/error_schema/subjects"} ->
+        json(["foobar"])
+
+      %{method: :get, url: "http://localhost:8081/error_schema/subjects/foobar/versions/latest"} ->
+        %Tesla.Env{status: 404, body: "Not Found"}
+
+      %{method: :get, url: "http://localhost:8081/error_decode/subjects"} ->
+        json(["foobar"])
+
+      %{method: :get, url: "http://localhost:8081/error_decode/subjects/foobar/versions/latest"} ->
+        json(%{"name" => "foobar", "version" => 1, "schema" => "invalid json"})
+    end)
+  end
+
+  def set_global_subject(subject) do
+    mock_global(fn
+      %{method: :get, url: "http://localhost:8081/subjects"} ->
+        json([subject])
+
+      %{method: :get, url: "http://localhost:8081/subjects/" <> _schema_path} ->
+        json(%{"name" => subject, "version" => 1, "schema" => "{\"type\": \"string\"}"})
+    end)
+  end
+end


### PR DESCRIPTION
- Use `Tesla.Mock` to unit test registry and server.
- Write doctests for cache.